### PR TITLE
Update workflow permissions to fix deploy error

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   deploy-book:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

Fixes [an error](https://github.com/software-gardening/almanac/actions/runs/9022374234/job/24795175759) with completing the deploy book jobs which I believe deal with permissions. It's a bit strange as this error doesn't always surface in other areas I've used the action. Just the same, [the docs](https://github.com/JamesIves/github-pages-deploy-action) recommend updating to this option (or others) (under "warning").

## What is the nature of your change?

- [ ] Content additions or updates (adds or updates content)
- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (these changes would cause existing functionality to not work as expected).

# Checklist

Please ensure that all boxes are checked before indicating that this pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own contributions.
- [ ] I have commented my content, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to related documentation (outside of book content).
- [x] My changes generate no new warnings.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added tests that prove my additions are effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
